### PR TITLE
fix bracket that messed up formatting

### DIFF
--- a/_posts/F-tools/2016-06-02-q-f-11.md
+++ b/_posts/F-tools/2016-06-02-q-f-11.md
@@ -8,7 +8,7 @@ permalink: /questions/F-11/
 
 **Short answer**
 
-: In principle, you can. But you should imho **not** use [PlantUML]](http://plantuml.com/) for static diagrams. Read the longer answer below for an explanation.
+: In principle, you can. But you should imho **not** use [PlantUML](http://plantuml.com/) for static diagrams. Read the longer answer below for an explanation.
 
 #### Longer answer
 


### PR DESCRIPTION
An additional "]" mixed up the formatting so that PlantUML wasn't rendered as a link