### PR TITLE
Fix typo

### DIFF
--- a/_posts/A-general/2015-02-06-q-a-11.md
+++ b/_posts/A-general/2015-02-06-q-a-11.md
@@ -15,7 +15,7 @@ license model somehow influence the license of this _template instance_?
 
 * You have absolutely NO obligation to publish or open-source your documentation
 (that means: you can, of course, keep your documents private and/or closed-source)
-* Your documentation can be put under any license or statues you require.
+* Your documentation can be put under any license or statutes you require.
 * If you need your document to be secret or confidential, that's fine for us.
 
 


### PR DESCRIPTION
Although I totally agree that a lot of documentation (not arc42!) is best put under a statue, or a wobbly table, I think you actually meant "statute".