### PR TITLE
Add documentation wrt. to arc42 help processing.

### DIFF
--- a/_posts/F-tools/2023-07-06-q-f-12.md
+++ b/_posts/F-tools/2023-07-06-q-f-12.md
@@ -8,8 +8,15 @@ permalink: /questions/F-12/
 
 **Short answer**
 
-: In principle, you can. 
+It is possible to switch off the integrated help by setting the AsciiDoc [Document Attribute](https://docs.asciidoctor.org/asciidoc/latest/attributes/document-attributes/) `arc42help` to false, e.g., in the [config.adoc](https://github.com/arc42/arc42-template/blob/d45afa79b29e49314cf9fc9ff21ab4527e4454c9/EN/asciidoc/src/config.adoc?plain=1#L10) file which is part of any AsciiDoc based arc42 template.
 
 #### Longer answer
 
-This question/answer was provided by [@aschemann](), who also came up with the underlying implementation in the asciidoc version of arc42. 
+AsciiDoc enables customization of contents, layout, and processing by so-called _document attributes_.
+These attributes can be defined in any place of the AsciiDoc documents.
+However, most often, global attributes are defined in the [document header](https://docs.asciidoctor.org/asciidoc/latest/document/header/).
+For arc42 the document header includes [a configuration file](https://github.com/arc42/arc42-template/blob/d45afa79b29e49314cf9fc9ff21ab4527e4454c9/EN/asciidoc/arc42-template.adoc?plain=1#L7) which contains settings which are customizable by the template user.
+By default, `arc42help` is switched to true, so that the generated HTML or PDF contains the help texts.
+You can switch off the help contents by setting the attribute to false by appending (or prepending) a `!`, i.e., `:!arc42help:`.
+
+This question/answer was provided by [@ascheman](https://github.com/ascheman), who also came up with the underlying implementation in the AsciiDoc version of arc42. 


### PR DESCRIPTION
Hopefully this small change provides enough context for any arc42 template user to switch off help text processing?